### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 joblib>=1.1.0
-numba==0.56.4
+numba==0.53.1
 numpy==1.23.5
 scipy==1.9.3
 librosa==0.9.1


### PR DESCRIPTION
encountering an error while trying to install the numba package using pip. The error message indicates that the installation failed because the package is not compatible with Python version (3.11.7).

The numba package only supports Python versions >=3.7 and <3.11, which means it's not compatible with Python version (3.11.7).
This might not be the latest version, but it should work with Python version 3.11.7.